### PR TITLE
Refactor Submitter#publish_job to allow method with no arguments, better error handling

### DIFF
--- a/lib/coney_island/submitter.rb
+++ b/lib/coney_island/submitter.rb
@@ -180,7 +180,7 @@ module ConeyIsland
       delay      ||= ConeyIsland.default_settings[:delay]
 
       # Just run this inline if we're not threaded
-      ConeyIsland::Job.new(nil, job_args).handle_job and return true if self.running_inline?
+      ConeyIsland::Job.new(nil, job_args).handle_job and return true if running_inline?
 
       # Is this delayed?
       if delay && delay.to_i > 0
@@ -212,6 +212,8 @@ module ConeyIsland
     # Publishes a job to a delayed queue exchange
     def self.publish_to_delay_queue(job_id, job_args, work_queue, delay)
       @delay_queue[work_queue] ||= {}
+
+      # TODO: Should this be in a different little method, say, bind_delay?
       unless @delay_queue[work_queue][delay].present?
         @delay_queue[work_queue][delay] ||= self.channel.queue(
           work_queue + '_delayed_' + delay.to_s, auto_delete: false, durable: true,

--- a/lib/coney_island/submitter.rb
+++ b/lib/coney_island/submitter.rb
@@ -10,7 +10,7 @@ module ConeyIsland
     end
 
     def self.running_inline?
-      @run_inline
+      !!@run_inline
     end
 
     def self.tcp_connection_retries=(number)
@@ -179,11 +179,11 @@ module ConeyIsland
       work_queue ||= ConeyIsland.default_settings[:work_queue]
       delay      ||= ConeyIsland.default_settings[:delay]
 
-      # Just run this inline if we're not threaded
-      ConeyIsland::Job.new(nil, job_args).handle_job and return true if running_inline?
-
-      # Is this delayed?
-      if delay && delay.to_i > 0
+      if self.running_inline?
+        # Just run this inline if we're not threaded
+        ConeyIsland::Job.new(nil, job_args).handle_job
+      elsif delay && delay.to_i > 0
+        # Is this delayed?
         # Publish to the delay exchange
         publish_to_delay_queue(job_id, job_args, work_queue, delay)
       else

--- a/test/submitter_test.rb
+++ b/test/submitter_test.rb
@@ -27,6 +27,20 @@ class SubmitterTest < MiniTest::Test
       end
     end
     describe "error handling" do
+      it "breaks if klass is not a class or a Module" do
+        error = assert_raises(ConeyIsland::JobArgumentError) do
+          ConeyIsland::Submitter.publish_job([:not_a_class, :method])
+        end
+        assert_match /to be a Class or Module/, error.message
+      end
+
+      it "breaks if the method_name is not a String or a Symbol" do
+        error = assert_raises(ConeyIsland::JobArgumentError) do
+          ConeyIsland::Submitter.publish_job([Class, 1])
+        end
+        assert_match /to be a String or a Symbol/, error.message
+      end
+
       it "handles argument errors for jobs" do
         assert_raises(ConeyIsland::JobArgumentError) do
           ConeyIsland::Submitter.publish_job([:not_a_class, :add_to_list, args: [[]]])


### PR DESCRIPTION
- Allow job_args to be empty (so we can just pass class and method name if the method has no args)
- We now provide context to why the argument is bad instead of just raising the ArgumentError.